### PR TITLE
Fix: import error from openzeppelin ERC20 structure modification

### DIFF
--- a/examples/basic/SimpleToken.sol
+++ b/examples/basic/SimpleToken.sol
@@ -17,7 +17,7 @@ contract SimpleToken is ERC20 {
   /**
    * @dev Constructor that gives msg.sender all of existing tokens.
    */
-  constructor() public ERC20("Bili", "BL") {
+  constructor() public ERC20("TaiyakiToken", "TYK") {
     _mint(msg.sender, INITIAL_SUPPLY);
   }
 

--- a/examples/basic/SimpleToken.sol
+++ b/examples/basic/SimpleToken.sol
@@ -1,7 +1,6 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.6.0;
 
-import "https://github.com/OpenZeppelin/openzeppelin-solidity/contracts/token/ERC20/ERC20Detailed.sol";
-import "https://github.com/OpenZeppelin/openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
+import "https://raw.githubusercontent.com/OpenZeppelin/openzeppelin-contracts/master/contracts/token/ERC20/ERC20.sol";
 
 
 /**
@@ -11,14 +10,14 @@ import "https://github.com/OpenZeppelin/openzeppelin-solidity/contracts/token/ER
  * `ERC20` functions.
  * Referenced from: https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/contracts/examples/SimpleToken.sol
  */
-contract SimpleToken is ERC20, ERC20Detailed {
+contract SimpleToken is ERC20 {
 
   uint256 public constant INITIAL_SUPPLY = 1e4 * (1e18);
 
   /**
    * @dev Constructor that gives msg.sender all of existing tokens.
    */
-  constructor() public ERC20Detailed("TaiyakiToken", "TYK", 18) {
+  constructor() public ERC20("Bili", "BL") {
     _mint(msg.sender, INITIAL_SUPPLY);
   }
 


### PR DESCRIPTION
1. Github changes its raw code storage path
2. Open Zeppelin migrates `ERC20Detailed ` to `ERC20Snapshot` and merge some function to `ERC20`,  keeping import `ERC20` only and modify contract constructor params.